### PR TITLE
[ELLA] Add functionality for expanded view of an event card in Admin …

### DIFF
--- a/src/app/admin/event-requests/[id]/page.tsx
+++ b/src/app/admin/event-requests/[id]/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useRouter, useParams } from "next/navigation";
+import { useState } from "react";
+import { EventDetails } from "@/components/left-event-details";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import type { EventData } from "@/components/user/event-request/EventRequestCard";
+import { AdminEventStatusPanel } from "@/components/admin/update-event-request/AdminEventStatusPanel";
+
+const adminEvents: EventData[] = [
+  {
+    id: 1,
+    status: "Awaiting Evaluation",
+    title: "Event1",
+    requestDate: "April 1, 2025",
+    eventDate: "April 18, 2025",
+    modality: "Online",
+    organizationName: "Org 1",
+  },
+  {
+    id: 2,
+    status: "Under Evaluation",
+    title: "Event2",
+    requestDate: "April 2, 2025",
+    eventDate: "April 20, 2025",
+    modality: "Online",
+    organizationName: "Org 2",
+  },
+  {
+    id: 3,
+    status: "Forwarded to Offices",
+    title: "Event3",
+    requestDate: "April 3, 2025",
+    eventDate: "April 21, 2025",
+    modality: "Online",
+    organizationName: "Org 3",
+  },
+  {
+    id: 4,
+    status: "Issues Found",
+    title: "Event4",
+    requestDate: "April 4, 2025",
+    eventDate: "April 25, 2025",
+    modality: "Online",
+
+    organizationName: "Org 4",
+  },
+  {
+    id: 5,
+    status: "Approved",
+    title: "Event5",
+    requestDate: "April 5, 2025",
+    eventDate: "April 27, 2025",
+    modality: "Online",
+    organizationName: "Org 5",
+  },
+  {
+    id: 6,
+    status: "Disapproved",
+    title: "Event6",
+    requestDate: "April 6, 2025",
+    eventDate: "April 30, 2025",
+    modality: "Online",
+
+    organizationName: "Org 6",
+  },
+];
+
+const STATUS_OPTIONS = [
+  "Under Evaluation",
+  "Forwarded to Offices",
+  "Issues Found",
+  "Approved",
+  "Disapproved",
+];
+
+const REQUIREMENTS: Record<string, string[]> = {
+  Online: [
+    "Request Letter",
+    "Signed Conforme of Adviser",
+    "Details of Activity",
+    "Letter of Partnership",
+  ],
+  "On Campus": [
+    "Request Letter",
+    "Signed Conforme of Adviser",
+    "Details of Activity",
+    "Letter of Partnership",
+    "Signed Security/Emergency Plan",
+    "Signed Health Protocol",
+    "Application Form for Use of UPV Venues/Facilities",
+  ],
+  "Off Campus": [
+    "Request Letter",
+    "Signed Conforme of Adviser",
+    "Details of Activity",
+    "Letter of Partnership",
+    "Signed Security/Emergency Plan",
+    "Signed Health Protocol",
+    "Detailed Medical Arrangement with First Aid Kit",
+    "Coordination with Concerned Offices",
+    "Waivers/Student Participation Agreement",
+    "List of Participants with Emergency Contact Details",
+    "Itinerary of Travel",
+  ],
+};
+
+// Main component for the expanded view of an event request
+export default function AdminEventRequestExpandedPage() {
+  const router = useRouter(); // Navigation hook
+  const { id } = useParams(); // Gets event ID from URL
+  const event = adminEvents.find((e: any) => String(e.id) === String(id)); // Find the event by ID
+  const [status, setStatus] = useState(event?.status || ""); // Track event status
+  const [checked, setChecked] = useState<string[]>([]); // Track checked requirements
+
+  // This is to show fallback if event does not exist
+  if (!event) return <div>Event not found</div>;
+
+  // To get the list of requirements based on event modality
+  const requirements = REQUIREMENTS[event.modality || "Online"];
+
+  // Toggle a requirement's checked state
+  const handleCheck = (req: string) => {
+    setChecked((prev) => (prev.includes(req) ? prev.filter((r) => r !== req) : [...prev, req]));
+  };
+
+  const handleStatusChange = (newStatus: string) => {
+    setStatus(newStatus);
+    // TODO: Update status in backend/db and trigger revalidation if needed
+  };
+
+  return (
+    <div className="flex gap-8 p-8 max-w-5xl mx-auto">
+      {/* Left: Event Details */}
+      <div className="flex-1">
+        <EventDetails event={event} />
+      </div>
+
+      {/* Right Column: Requirements checklist and status update panel */}
+      <div className="flex-1 space-y-8">
+        <div>
+          <h2 className="font-bold mb-2">Requirements Checklist</h2>
+          <ul className="space-y-2">
+            {requirements.map((req) => (
+              <li key={req} className="flex items-center gap-2">
+                <Checkbox
+                  checked={checked.includes(req)}
+                  onCheckedChange={() => handleCheck(req)}
+                />
+                <span>{req}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div>
+          <AdminEventStatusPanel
+            status={status}
+            onStatusChange={handleStatusChange}
+            onSubmit={(data) => {
+              // TODO: Save data to backend
+              setStatus(data.status);
+              alert("Changes saved! (Stub)");
+            }}
+          />
+        </div>
+
+        {/* Back Button */}
+        <Button variant="secondary" onClick={() => router.back()}>
+          Back to List
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/event-requests/page.tsx
+++ b/src/app/admin/event-requests/page.tsx
@@ -8,7 +8,9 @@ import { ChevronDown } from "lucide-react";
 import SortModal from "@/components/ui/SortModal";
 import { FilterModal } from "@/components/ui/filter-modal";
 import { EventRequestTabs } from "@/components/user/event-request/EventRequestTabs";
+import { useRouter } from "next/navigation";
 
+// Define the shape of the filter options
 type FilterOptions = {
   search: string;
   modality: "" | "Online" | "On-Site";
@@ -18,35 +20,60 @@ type FilterOptions = {
 const adminEvents: EventData[] = [
   {
     id: 1,
+    status: "Awaiting Evaluation",
     title: "Event1",
     requestDate: "April 1, 2025",
-    eventDate: "April 10, 2025",
-    status: "Awaiting Evaluation",
-    organizationName: "Organization Name",
+    eventDate: "April 18, 2025",
     modality: "Online",
-    location: "Iloilo",
+    organizationName: "Org 1",
   },
   {
     id: 2,
+    status: "Under Evaluation",
     title: "Event2",
-    requestDate: "April 5, 2025",
-    eventDate: "April 15, 2025",
-    status: "Issues Found",
-    organizationName: "Komsai.Org",
+    requestDate: "April 2, 2025",
+    eventDate: "April 20, 2025",
     modality: "Online",
-    location: "Iloilo",
+    organizationName: "Org 2",
   },
   {
     id: 3,
+    status: "Forwarded to Offices",
     title: "Event3",
-    requestDate: "April 20, 2025",
-    eventDate: "April 25, 2025",
-    status: "Disapproved",
-    organizationName: "Miagao Valley",
+    requestDate: "April 3, 2025",
+    eventDate: "April 21, 2025",
     modality: "Online",
-    location: "Iloilo",
+    organizationName: "Org 3",
   },
-  // ...other events
+  {
+    id: 4,
+    status: "Issues Found",
+    title: "Event4",
+    requestDate: "April 4, 2025",
+    eventDate: "April 25, 2025",
+    modality: "Online",
+
+    organizationName: "Org 4",
+  },
+  {
+    id: 5,
+    status: "Approved",
+    title: "Event5",
+    requestDate: "April 5, 2025",
+    eventDate: "April 27, 2025",
+    modality: "Online",
+    organizationName: "Org 5",
+  },
+  {
+    id: 6,
+    status: "Disapproved",
+    title: "Event6",
+    requestDate: "April 6, 2025",
+    eventDate: "April 30, 2025",
+    modality: "Online",
+
+    organizationName: "Org 6",
+  },
 ];
 
 const statusOptions = [
@@ -59,7 +86,10 @@ const statusOptions = [
 ];
 
 export default function AdminEventRequestsPage() {
+  // Modal visibility state
   const [isSortModalOpen, setSortModalOpen] = React.useState(false);
+
+  // Sorting options state (e.g., by request date)
   const [sortOption, setSortOption] = React.useState<{
     type: string;
     order?: string;
@@ -75,6 +105,7 @@ export default function AdminEventRequestsPage() {
     location: "",
   });
   const [activeTab, setActiveTab] = React.useState("All");
+  const router = useRouter();
 
   // Filtering logic
   const filteredEvents = adminEvents.filter(
@@ -114,6 +145,7 @@ export default function AdminEventRequestsPage() {
             label="Organization/Request Title"
           />
         </div>
+
         <Button
           variant="outline"
           className="bg-[#284b3e] text-white hover:bg-[#284b3e]/90"
@@ -129,19 +161,33 @@ export default function AdminEventRequestsPage() {
           Sort By <ChevronDown className="ml-2 h-4 w-4" />
         </Button>
       </div>
+
+      {/* NavBar for filtering by status */}
       <EventRequestTabs activeTab={activeTab} setActiveTab={setActiveTab} />
+
+      {/* List of event request cards */}
       <div className="flex flex-col items-center">
-        <div className="space-y-4 w-[1000px]">
+        <div className="mt-5 space-y-4 w-[1000px]">
           {sortedEvents.map((event) => (
-            <EventRequestCard key={event.id} event={event} showAccordion={false} />
+            <div
+              key={event.id}
+              onClick={() => router.push(`/admin/event-requests/${event.id}`)}
+              className="cursor-pointer"
+            >
+              <EventRequestCard event={event} showAccordion={false} />
+            </div>
           ))}
         </div>
       </div>
+
+      {/* Sort modal popup */}
       <SortModal
         isOpen={isSortModalOpen}
         onClose={() => setSortModalOpen(false)}
         onApply={(option) => setSortOption(option)}
       />
+
+      {/* Filter modal popup */}
       <FilterModal
         isOpen={isFilterOpen}
         onClose={() => setFilterOpen(false)}

--- a/src/app/user/home/page.tsx
+++ b/src/app/user/home/page.tsx
@@ -12,7 +12,7 @@ export default function UserHomePage() {
   return (
     <div className="flex justify-center items-center min-h-screen">
 
-      <EventRequestDialog open={open} setOpen={setOpen} />
+      <EventRequestDialog open={openDialog} setOpen={setOpenDialog} />
     </div> 
 
   );

--- a/src/components/admin/update-event-request/AdminEventStatusPanel.tsx
+++ b/src/components/admin/update-event-request/AdminEventStatusPanel.tsx
@@ -1,0 +1,148 @@
+import React, { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import FileUploadForm from "@/components/ui/file-upload-form";
+import { Checkbox } from "@/components/ui/checkbox";
+
+// Steps used when status is "Forwarded to Offices"
+const officeSteps = [
+  { key: "osa", label: "Forwarded to OSA Director" },
+  { key: "ovcaa", label: "Forwarded to OVCA/OVCAA" },
+  { key: "chancellor", label: "Forwarded to Chancellor" },
+];
+
+// Main component for updating an event's status in the admin panel
+export function AdminEventStatusPanel({
+  status, // current status value
+  onStatusChange, // callback to update status
+  onSubmit, // callback for submitting the updated data
+  initialData = {}, // optional initial values (for editing an existing item)
+}: {
+  status: string;
+  onStatusChange: (status: string) => void;
+  onSubmit: (data: any) => void;
+  initialData?: any;
+}) {
+  // Local state for comment/note input
+  const [comment, setComment] = useState(initialData.comment || "");
+  // State for uploaded file (if any)
+  const [file, setFile] = useState<File | null>(null);
+  // List of issues entered by the user
+  const [issues, setIssues] = useState<string[]>(initialData.issues || []);
+  // Current text input for a new issue
+  const [issueInput, setIssueInput] = useState("");
+  // Tracks checkbox progress for each office step
+  const [progress, setProgress] = useState<{ [k: string]: boolean }>(
+    initialData.progress || {}
+  );
+
+  // Adds the issue from the input to the issues list
+  const handleAddIssue = () => {
+    if (issueInput.trim()) {
+      setIssues([...issues, issueInput.trim()]);
+      setIssueInput("");
+    }
+  };
+
+  // Toggles the progress checkbox for a given office step
+  const handleProgressChange = (key: string) => {
+    setProgress((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  // UI rendering starts here
+  return (
+    <div className="space-y-4">
+      {/* Dropdown for selecting status */}
+      <label className="block font-medium mb-1">Update Status</label>
+      <select
+        value={status}
+        onChange={(e) => onStatusChange(e.target.value)}
+        className="w-full border rounded px-3 py-2"
+      >
+        <option value="Awaiting Evaluation">Awaiting Evaluation</option>
+        <option value="Under Evaluation">Under Evaluation</option>
+        <option value="Forwarded to Offices">Forwarded to Offices</option>
+        <option value="Issues Found">Issues Found</option>
+        <option value="Approved">Approved</option>
+        <option value="Disapproved">Disapproved</option>
+      </select>
+
+      {/* Show comments and file upload for terminal states */}
+      {(status === "Disapproved" || status === "Approved") && (
+        <>
+          <label className="block font-medium">Comments/Notes</label>
+          <Textarea
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="Enter comments or notes here..."
+          />
+          {/* File upload depending on approval type */}
+          <label className="block font-medium mt-2">
+            {status === "Disapproved"
+              ? "Notice of Disapproval File"
+              : "Notice of Approval File"}
+          </label>
+          <FileUploadForm />
+        </>
+      )}
+
+      {/* Show dynamic list of issues for status "Issues Found" */}
+      {status === "Issues Found" && (
+        <>
+          <label className="block font-medium">List Issues</label>
+          <div className="flex gap-2">
+            <Input
+              value={issueInput}
+              onChange={(e) => setIssueInput(e.target.value)}
+              placeholder="Describe an issue"
+            />
+            <Button type="button" onClick={handleAddIssue}>
+              Add
+            </Button>
+          </div>
+          <ul className="list-disc ml-6">
+            {issues.map((issue, idx) => (
+              <li key={idx}>{issue}</li>
+            ))}
+          </ul>
+        </>
+      )}
+
+      {/* Show progress checkboxes for status "Forwarded to Offices" */}
+      {status === "Forwarded to Offices" && (
+        <>
+          <label className="block font-medium">Progress</label>
+          <div className="space-y-2">
+            {officeSteps.map((step) => (
+              <div key={step.key} className="flex items-center gap-2">
+                <Checkbox
+                  checked={!!progress[step.key]}
+                  onCheckedChange={() => handleProgressChange(step.key)}
+                  id={step.key}
+                />
+                <label htmlFor={step.key}>{step.label}</label>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Submit button that triggers onSubmit with all the collected data */}
+      <Button
+        className="w-full bg-[#284b3e] hover:bg-[#284b3e]/90"
+        onClick={() =>
+          onSubmit({
+            status,
+            comment,
+            file,
+            issues,
+            progress,
+          })
+        }
+      >
+        Save Changes
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/src/components/user/event-request/EventRequestCard.tsx
+++ b/src/components/user/event-request/EventRequestCard.tsx
@@ -101,7 +101,6 @@ export function EventRequestCard({ event, showAccordion = true }: EventRequestCa
           <div>
             {event.status === "Awaiting Evaluation" && (
               <>
-
                 <div className="max-w-xs">
                   <p className="mb-4 break-words whitespace-normal w-full">
                     Your request has been submitted and is waiting to be reviewed by the appropriate


### PR DESCRIPTION
CHANGES:
1. Event Request Card is now clickable
2. Redirect to new page for the expanded view
-Reused left-event-details
-Created the right side interface (checkbox for requirements and AdminEventStatusPanel)
**NOTE: do npm install for checkbox**

![image](https://github.com/user-attachments/assets/ceb7d6d3-9b46-471e-b886-3d41b14564c6)

3. Adds status update interface (based on selected status on dropdown)

**Approved/Disapproved Status**
-Has comment box and file upload
![image](https://github.com/user-attachments/assets/534a73af-d3ef-44d7-8103-f3bc8a816b1b)

**Issues Found Status**
-Has text field input to add one by one the issues found, to generate a bulleted list
![image](https://github.com/user-attachments/assets/f75cc627-715b-4a64-b47c-b165a3e20add)

**Forwarded to Offices Status**
-Has checkbox for to update current & past channel progress
![image](https://github.com/user-attachments/assets/925e8df3-6867-49dd-b68e-fa1115fdb714)

**Awaiting and Under Evaluation**
-Only has save button
![image](https://github.com/user-attachments/assets/e06e04e6-363e-4394-b503-3e1f1903b5ad)
